### PR TITLE
Support multi-car in real cars with updated namespace.

### DIFF
--- a/mushr_base/launch/includes/joy_teleop.launch
+++ b/mushr_base/launch/includes/joy_teleop.launch
@@ -4,6 +4,7 @@
 
   <rosparam file="$(arg joy_teleop_config)" command="load" />
 
+  <arg name="car_name" />
   <node pkg="joy" type="joy_node" name="joy_node" />
-  <node pkg="mushr_base" type="joy_teleop.py" name="joy_teleop" />
+  <node pkg="mushr_base" type="joy_teleop.py" name="joy_teleop" args="$(arg car_name)" />
 </launch>

--- a/mushr_base/launch/includes/joy_teleop.launch
+++ b/mushr_base/launch/includes/joy_teleop.launch
@@ -4,7 +4,9 @@
 
   <rosparam file="$(arg joy_teleop_config)" command="load" />
 
-  <arg name="car_name" />
+  <arg name="car_name" default="/car" />
   <node pkg="joy" type="joy_node" name="joy_node" />
-  <node pkg="mushr_base" type="joy_teleop.py" name="joy_teleop" args="$(arg car_name)" />
+  <node pkg="mushr_base" type="joy_teleop.py" name="joy_teleop">
+    <param name="car_name" value="$(arg car_name)" />
+  </node>
 </launch>

--- a/mushr_base/launch/teleop.launch
+++ b/mushr_base/launch/teleop.launch
@@ -20,7 +20,7 @@
     </group>
     <group ns="teleop">
         <include file="$(find mushr_base)/launch/includes/joy_teleop.launch">
-            <arg name="car_name" default="/$(arg car_name)" />
+            <arg name="car_name" value="/$(arg car_name)" />
         </include>
     </group>
 

--- a/mushr_base/launch/teleop.launch
+++ b/mushr_base/launch/teleop.launch
@@ -1,22 +1,27 @@
 <!-- -*- mode: XML -*- -->
 <launch>
   <!-- Change car name to match the name of the car, e.g. car1 -->
-  <arg name="car_name" default="car">
-  <group ns="$(arg car_name)">
+  <arg name="car_name" default="car" />
 
-    <!-- Could be racecar-mit, racecar-uw-tx2, or racecar-uw-nano -->
-    <arg name="racecar_version" default="racecar-uw-nano" />
+  <!-- Could be racecar-mit, racecar-uw-tx2, or racecar-uw-nano -->
+  <arg name="racecar_version" default="racecar-uw-nano" />
+
+
+  <group ns="$(arg car_name)">
 
     <param name="robot_description"
            textfile="$(find mushr_description)/robots/$(arg racecar_version).urdf"/>
 
     <group ns="vesc">
          <include file="$(find vesc_main)/launch/vesc.launch">
-                 <arg name="racecar_version" value="$(arg racecar_version)" />
+             <arg name="racecar_version" value="$(arg racecar_version)" />
+             <arg name="car_name" default="/$(arg car_name)" />
          </include>
     </group>
     <group ns="teleop">
-        <include file="$(find mushr_base)/launch/includes/joy_teleop.launch" />
+        <include file="$(find mushr_base)/launch/includes/joy_teleop.launch">
+            <arg name="car_name" default="/$(arg car_name)" />
+        </include>
     </group>
 
     <group ns="mux">
@@ -26,10 +31,11 @@
     <include file="$(find mushr_hardware)/launch/$(arg racecar_version)/sensors.launch" >
         <arg name="racecar_version" value="$(arg racecar_version)" />
         <arg name="tf_prefix" value="$(arg car_name)" />
+        <arg name="car_name" default="$(arg car_name)" />
     </include>
 
     <include file="$(find mushr_base)/launch/includes/racecar_state.launch">
-      <arg name="tf_prefix" value="$(arg car_name)" />
+        <arg name="tf_prefix" value="$(arg car_name)" />
     </include>
 
     <node pkg="robot_state_publisher" type="robot_state_publisher" name="state_publisher">

--- a/mushr_base/launch/teleop.launch
+++ b/mushr_base/launch/teleop.launch
@@ -1,30 +1,41 @@
 <!-- -*- mode: XML -*- -->
 <launch>
-  <!-- Could be racecar-mit, racecar-uw-tx2, or racecar-uw-nano -->
-  <arg name="racecar_version" default="racecar-uw-nano" />
+  <!-- Change car name to match the name of the car, e.g. car1 -->
+  <arg name="car_name" default="car">
+  <group ns="$(arg car_name)">
 
-  <param name="robot_description"
-         textfile="$(find mushr_description)/robots/$(arg racecar_version).urdf"/>
+    <!-- Could be racecar-mit, racecar-uw-tx2, or racecar-uw-nano -->
+    <arg name="racecar_version" default="racecar-uw-nano" />
 
-  <group ns="vesc">
-  	<include file="$(find vesc_main)/launch/vesc.launch">
-        	<arg name="racecar_version" value="$(arg racecar_version)" />
-  	</include>
+    <param name="robot_description"
+           textfile="$(find mushr_description)/robots/$(arg racecar_version).urdf"/>
+
+    <group ns="vesc">
+         <include file="$(find vesc_main)/launch/vesc.launch">
+                 <arg name="racecar_version" value="$(arg racecar_version)" />
+         </include>
+    </group>
+    <group ns="teleop">
+        <include file="$(find mushr_base)/launch/includes/joy_teleop.launch" />
+    </group>
+
+    <group ns="mux">
+        <include file="$(find ackermann_cmd_mux)/launch/mux.launch" />
+    </group>
+
+    <include file="$(find mushr_hardware)/launch/$(arg racecar_version)/sensors.launch" >
+        <arg name="racecar_version" value="$(arg racecar_version)" />
+        <arg name="tf_prefix" value="$(arg car_name)" />
+    </include>
+
+    <include file="$(find mushr_base)/launch/includes/racecar_state.launch">
+      <arg name="tf_prefix" value="$(arg car_name)" />
+    </include>
+
+    <node pkg="robot_state_publisher" type="robot_state_publisher" name="state_publisher">
+      <param name="tf_prefix" value="$(arg car_name)"/>
+      <param name="robot_description" value="/$(arg car_name)/robot_description"/>
+    </node>
+
   </group>
-
-  <group ns="teleop">
-      <include file="$(find mushr_base)/launch/includes/joy_teleop.launch" />
-  </group>
-
-  <group ns="mux">
-      <include file="$(find ackermann_cmd_mux)/launch/mux.launch" />
-  </group>
-
-  <include file="$(find mushr_hardware)/launch/$(arg racecar_version)/sensors.launch" >
-      <arg name="racecar_version" value="$(arg racecar_version)" />
-  </include>
-
-  <include file="$(find mushr_base)/launch/includes/racecar_state.launch" />
-  <node pkg="robot_state_publisher" type="robot_state_publisher" name="state_publisher"/>
-
 </launch>

--- a/mushr_base/src/joy_teleop.py
+++ b/mushr_base/src/joy_teleop.py
@@ -32,12 +32,10 @@ class JoyTeleop:
     See config/joy_teleop.yaml for an example.
     """
 
-    def __init__(self, car_name):
-        self.CAR_NAME = car_name
-        if len(self.CAR_NAME) > 0:
-            self.CAR_NAME = self.CAR_NAME + "/"
-            if not self.CAR_NAME.startswith("/"):
-                self.CAR_NAME = "/" + self.CAR_NAME
+    def __init__(self):
+        self.CAR_NAME = rospy.get_param("~car_name", "/car")
+        if not self.CAR_NAME.endswith("/"):
+            self.CAR_NAME += "/"
 
         if not rospy.has_param("teleop"):
             rospy.logfatal("no configuration was found, taking node down")
@@ -348,12 +346,9 @@ class JoyTeleop:
 
 
 if __name__ == "__main__":
-    import sys
-    car_name = "/car" if len(sys.argv) < 2 else sys.argv[1]
-
     try:
         rospy.init_node("joy_teleop")
-        jt = JoyTeleop(car_name=car_name)
+        jt = JoyTeleop()
         rospy.spin()
     except JoyTeleopException:
         pass

--- a/mushr_base/src/joy_teleop.py
+++ b/mushr_base/src/joy_teleop.py
@@ -32,9 +32,9 @@ class JoyTeleop:
     See config/joy_teleop.yaml for an example.
     """
 
-    def __init__(self):
+    def __init__(self, car_name):
         # Append this prefix to any broadcasted TFs
-        self.CAR_NAME = str(rospy.get_param("~car_name", "/car").rstrip("/"))
+        self.CAR_NAME = car_name
         if len(self.CAR_NAME) > 0:
             self.CAR_NAME = self.CAR_NAME + "/"
         self.TELEOP_PARAM = self.CAR_NAME + "teleop/teleop"
@@ -63,7 +63,7 @@ class JoyTeleop:
             action_type = teleop_cfg[i]["type"]
             self.add_command(i, teleop_cfg[i])
             if action_type == "topic":
-                self.register_topic(i, self.CAR_NAME + teleop_cfg[i])
+                self.register_topic(i, teleop_cfg[i])
             elif action_type == "action":
                 self.register_action(i, teleop_cfg[i])
             elif action_type == "service":
@@ -90,7 +90,10 @@ class JoyTeleop:
 
     def register_topic(self, name, command):
         """Add a topic publisher for a joystick command"""
-        topic_name = command["topic_name"]
+        if command["topic_name"].startswith("/"):
+            topic_name = command["topic_name"]
+        else:
+            topic_name = self.CAR_NAME + command["topic_name"]
 
         try:
             topic_type = self.get_message_type(command["message_type"])
@@ -342,9 +345,12 @@ class JoyTeleop:
 
 
 if __name__ == "__main__":
+    import sys
+    car_name = "" if len(sys.argv) < 2 else sys.argv[1]
+
     try:
         rospy.init_node("joy_teleop")
-        jt = JoyTeleop()
+        jt = JoyTeleop(car_name=car_name)
         rospy.spin()
     except JoyTeleopException:
         pass

--- a/mushr_base/src/racecar_state.py
+++ b/mushr_base/src/racecar_state.py
@@ -164,7 +164,7 @@ class RacecarState:
 
         # Subscribes to the initial pose of the car
         self.init_pose_sub = rospy.Subscriber(
-            "/initialpose", PoseWithCovarianceStamped, self.init_pose_cb, queue_size=1
+            "initialpose", PoseWithCovarianceStamped, self.init_pose_cb, queue_size=1
         )
 
         # Subscribes to info about the bldc (particularly the speed in rpm)


### PR DESCRIPTION
This PR enables multi-car control by creating namespaces and `tf_prefix`. This PR is to be merged in conjunction with other PRs in prl-mushr/vesc#2 and `mushr`. 