### PR TITLE
Modify argument names for map saver compatibility

### DIFF
--- a/mushr_base/launch/includes/slam.launch
+++ b/mushr_base/launch/includes/slam.launch
@@ -2,43 +2,44 @@
         <!-- Change car name to match the name of the car, e.g. car1 -->
         <arg name="car_name" default="car" />
         <group ns="$(arg car_name)">
-	<node name="laser_slam_node" type="slam_gmapping" pkg="gmapping">                                                    
-		<param name="throttle_scans" type="int" value="1"/>
-		<param name="base_frame" type="string" value="$(arg car_name)/base_link"/>
-		<param name="map_frame" type="string" value="$(arg car_name)/map"/>
-		<param name="odom_frame" type="string" value="$(arg car_name)/odom"/>
-		<param name="map_update_interval" type="double" value="5.0"/>
-		<param name="maxUrange" type="double" value="5.59"/>
-		<param name="sigma" type="double" value="0.05"/>
-		<param name="kernelSize" type="int" value="1" />
-		<param name="lstep" type="double" value="0.05"/>
-		<param name="astep" type="double" value="0.05"/>
-		<param name="iterations" type="int" value="5"/>
-		<param name="lsigma" type="double" value="0.075"/>
-		<param name="ogain" type="double" value="3.0"/>
-		<param name="lskip" type="int" value="0"/>
-		<param name="minimumScore" type="double" value="0.0"/>
-		<param name="srr" type="double" value="0.1"/>
-		<param name="srt" type="double" value="0.2"/>
-		<param name="str" type="double" value="0.1"/>
-		<param name="stt" type="double" value="0.2"/>
-		<param name="linearUpdate" type="double" value="1.0"/>
-		<param name="angularUpdate" type="double" value="0.5"/>
-		<param name="temporalUpdate" type="double" value="-1.0"/>
-		<param name="resampleThreshold" type="double" value="0.5"/>
-		<param name="particles" type="int" value="30"/>
-		<param name="xmin" type="double" value="-100"/>
-		<param name="ymin" type="double" value="-100"/>
-		<param name="xmax" type="double" value="100"/>
-		<param name="ymax" type="double" value="100"/>
-		<param name="delta" type="double" value="0.05"/>
-		<param name="llsamplerange" type="double" value="0.01"/>
-		<param name="llsamplestep" type="double" value="0.01"/>
-		<param name="lasamplerange" type="double" value="0.005"/>
-		<param name="lasamplestep" type="double" value="0.005"/>
-		<param name="transform_publish_period" type="double" value="0.05"/>		
-		<param name="occ_thresh" type="double" value="0.25"/>
-		<param name="maxRange" type="double" value="11.0"/>		
-	</node>
+        <node name="laser_slam_node" type="slam_gmapping" pkg="gmapping">
+                <param name="throttle_scans" type="int" value="1"/>
+                <param name="base_frame" type="string" value="$(arg car_name)/base_link"/>
+                <param name="map_frame" type="string" value="$(arg car_name)/map"/>
+                <param name="odom_frame" type="string" value="$(arg car_name)/odom"/>
+                <param name="map_update_interval" type="double" value="5.0"/>
+                <param name="maxUrange" type="double" value="5.59"/>
+                <param name="sigma" type="double" value="0.05"/>
+                <param name="kernelSize" type="int" value="1" />
+                <param name="lstep" type="double" value="0.05"/>
+                <param name="astep" type="double" value="0.05"/>
+                <param name="iterations" type="int" value="5"/>
+                <param name="lsigma" type="double" value="0.075"/>
+                <param name="ogain" type="double" value="3.0"/>
+                <param name="lskip" type="int" value="0"/>
+                <param name="minimumScore" type="double" value="0.0"/>
+                <param name="srr" type="double" value="0.1"/>
+                <param name="srt" type="double" value="0.2"/>
+                <param name="str" type="double" value="0.1"/>
+                <param name="stt" type="double" value="0.2"/>
+                <param name="linearUpdate" type="double" value="1.0"/>
+                <param name="angularUpdate" type="double" value="0.5"/>
+                <param name="temporalUpdate" type="double" value="-1.0"/>
+                <param name="resampleThreshold" type="double" value="0.5"/>
+                <param name="particles" type="int" value="30"/>
+                <param name="xmin" type="double" value="-100"/>
+                <param name="ymin" type="double" value="-100"/>
+                <param name="xmax" type="double" value="100"/>
+                <param name="ymax" type="double" value="100"/>
+                <param name="delta" type="double" value="0.05"/>
+                <param name="llsamplerange" type="double" value="0.01"/>
+                <param name="llsamplestep" type="double" value="0.01"/>
+                <param name="lasamplerange" type="double" value="0.005"/>
+                <param name="lasamplestep" type="double" value="0.005"/>
+                <param name="transform_publish_period" type="double" value="0.05"/>
+                <param name="occ_thresh" type="double" value="0.25"/>
+                <param name="maxRange" type="double" value="11.0"/>
+        </node>
 </group>
 </launch>
+

--- a/mushr_base/launch/includes/slam.launch
+++ b/mushr_base/launch/includes/slam.launch
@@ -1,9 +1,12 @@
 <launch>
-	<node name="laser_slam_node" type="slam_gmapping" pkg="gmapping">
+        <!-- Change car name to match the name of the car, e.g. car1 -->
+        <arg name="car_name" default="car" />
+        <group ns="$(arg car_name)">
+	<node name="laser_slam_node" type="slam_gmapping" pkg="gmapping">                                                    
 		<param name="throttle_scans" type="int" value="1"/>
-		<param name="base_frame" type="string" value="base_link"/>
-		<param name="map_frame" type="string" value="map"/>
-		<param name="odom_frame" type="string" value="odom"/>
+		<param name="base_frame" type="string" value="$(arg car_name)/base_link"/>
+		<param name="map_frame" type="string" value="$(arg car_name)/map"/>
+		<param name="odom_frame" type="string" value="$(arg car_name)/odom"/>
 		<param name="map_update_interval" type="double" value="5.0"/>
 		<param name="maxUrange" type="double" value="5.59"/>
 		<param name="sigma" type="double" value="0.05"/>
@@ -37,5 +40,5 @@
 		<param name="occ_thresh" type="double" value="0.25"/>
 		<param name="maxRange" type="double" value="11.0"/>		
 	</node>
-
+</group>
 </launch>

--- a/mushr_base/launch/includes/slam.launch
+++ b/mushr_base/launch/includes/slam.launch
@@ -2,44 +2,44 @@
         <!-- Change car name to match the name of the car, e.g. car1 -->
         <arg name="car_name" default="car" />
         <group ns="$(arg car_name)">
-        <node name="laser_slam_node" type="slam_gmapping" pkg="gmapping">
-                <param name="throttle_scans" type="int" value="1"/>
-                <param name="base_frame" type="string" value="$(arg car_name)/base_link"/>
-                <param name="map_frame" type="string" value="$(arg car_name)/map"/>
-                <param name="odom_frame" type="string" value="$(arg car_name)/odom"/>
-                <param name="map_update_interval" type="double" value="5.0"/>
-                <param name="maxUrange" type="double" value="5.59"/>
-                <param name="sigma" type="double" value="0.05"/>
-                <param name="kernelSize" type="int" value="1" />
-                <param name="lstep" type="double" value="0.05"/>
-                <param name="astep" type="double" value="0.05"/>
-                <param name="iterations" type="int" value="5"/>
-                <param name="lsigma" type="double" value="0.075"/>
-                <param name="ogain" type="double" value="3.0"/>
-                <param name="lskip" type="int" value="0"/>
-                <param name="minimumScore" type="double" value="0.0"/>
-                <param name="srr" type="double" value="0.1"/>
-                <param name="srt" type="double" value="0.2"/>
-                <param name="str" type="double" value="0.1"/>
-                <param name="stt" type="double" value="0.2"/>
-                <param name="linearUpdate" type="double" value="1.0"/>
-                <param name="angularUpdate" type="double" value="0.5"/>
-                <param name="temporalUpdate" type="double" value="-1.0"/>
-                <param name="resampleThreshold" type="double" value="0.5"/>
-                <param name="particles" type="int" value="30"/>
-                <param name="xmin" type="double" value="-100"/>
-                <param name="ymin" type="double" value="-100"/>
-                <param name="xmax" type="double" value="100"/>
-                <param name="ymax" type="double" value="100"/>
-                <param name="delta" type="double" value="0.05"/>
-                <param name="llsamplerange" type="double" value="0.01"/>
-                <param name="llsamplestep" type="double" value="0.01"/>
-                <param name="lasamplerange" type="double" value="0.005"/>
-                <param name="lasamplestep" type="double" value="0.005"/>
-                <param name="transform_publish_period" type="double" value="0.05"/>
-                <param name="occ_thresh" type="double" value="0.25"/>
-                <param name="maxRange" type="double" value="11.0"/>
-        </node>
-</group>
+                <node name="laser_slam_node" type="slam_gmapping" pkg="gmapping">
+                        <param name="throttle_scans" type="int" value="1"/>
+                        <param name="base_frame" type="string" value="$(arg car_name)/base_link"/>
+                        <param name="map_frame" type="string" value="$(arg car_name)/map"/>
+                        <param name="odom_frame" type="string" value="$(arg car_name)/odom"/>
+                        <param name="map_update_interval" type="double" value="5.0"/>
+                        <param name="maxUrange" type="double" value="5.59"/>
+                        <param name="sigma" type="double" value="0.05"/>
+                        <param name="kernelSize" type="int" value="1" />
+                        <param name="lstep" type="double" value="0.05"/>
+                        <param name="astep" type="double" value="0.05"/>
+                        <param name="iterations" type="int" value="5"/>
+                        <param name="lsigma" type="double" value="0.075"/>
+                        <param name="ogain" type="double" value="3.0"/>
+                        <param name="lskip" type="int" value="0"/>
+                        <param name="minimumScore" type="double" value="0.0"/>
+                        <param name="srr" type="double" value="0.1"/>
+                        <param name="srt" type="double" value="0.2"/>
+                        <param name="str" type="double" value="0.1"/>
+                        <param name="stt" type="double" value="0.2"/>
+                        <param name="linearUpdate" type="double" value="1.0"/>
+                        <param name="angularUpdate" type="double" value="0.5"/>
+                        <param name="temporalUpdate" type="double" value="-1.0"/>
+                        <param name="resampleThreshold" type="double" value="0.5"/>
+                        <param name="particles" type="int" value="30"/>
+                        <param name="xmin" type="double" value="-100"/>
+                        <param name="ymin" type="double" value="-100"/>
+                        <param name="xmax" type="double" value="100"/>
+                        <param name="ymax" type="double" value="100"/>
+                        <param name="delta" type="double" value="0.05"/>
+                        <param name="llsamplerange" type="double" value="0.01"/>
+                        <param name="llsamplestep" type="double" value="0.01"/>
+                        <param name="lasamplerange" type="double" value="0.005"/>
+                        <param name="lasamplestep" type="double" value="0.005"/>
+                        <param name="transform_publish_period" type="double" value="0.05"/>
+                        <param name="occ_thresh" type="double" value="0.25"/>
+                        <param name="maxRange" type="double" value="11.0"/>
+                </node>
+        </group>
 </launch>
 


### PR DESCRIPTION
In order to have the laser_slam_node publish to /car/map for the gmapping to work, we have to modify the argument names to ensure that is consistent with the car name.

This resolves an issue with the laser_slam_node publishing to /map instead of /car/map which causes duplicate nodes and doesn't allow the gmapping to be viewed in rviz, or saved by map_saver later.