### PR TITLE
converter node added

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ catkin_python_setup()
 catkin_package()
 
 
-catkin_install_python(PROGRAMS scripts/racecar_state scripts/joy_teleop
+catkin_install_python(PROGRAMS scripts/racecar_state scripts/joy_teleop scripts/nav_msg_converter
         DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
 install(DIRECTORY config launch maps

--- a/launch/includes/nav_msg_converter.launch
+++ b/launch/includes/nav_msg_converter.launch
@@ -1,0 +1,19 @@
+<!-- -*- mode: XML -*- -->
+<launch>
+  <arg name="start_topic" default="/initialpose" />
+  <arg name="estimate_topic" default="/pose_estimate" />
+  <arg name="goal_topic" default="/move_base_simple/goal" />
+  <arg name="car_name" default="car" />
+  <arg name="pose_topic" default="/foxglove/pose_stamped" />
+  <arg name="type_topic" default="/foxglove/click_type" />
+
+  <!-- <node pkg="nav_msg_converter" type="nav_msg_converter_node" name="nav_msg_converter_node" /> -->
+  <node pkg="mushr_sim" type="nav_msg_converter" name="nav_msg_converter">
+    <param name="car_name" value="$(arg car_name)" />
+    <param name="start_topic" value="/$(arg car_name)$(arg start_topic)" />
+    <param name="goal_topic" value="$(arg goal_topic)" />
+    <param name="pose_topic" value="$(arg pose_topic)" />
+    <param name="estimate_topic" value="$(arg estimate_topic)" />
+    <param name="type_topic" value="$(arg type_topic)" />
+  </node>
+</launch>

--- a/launch/includes/nav_msg_converter.launch
+++ b/launch/includes/nav_msg_converter.launch
@@ -1,6 +1,6 @@
 <!-- -*- mode: XML -*- -->
 <launch>
-  <arg name="start_topic" default="/initialpose" />
+  <arg name="start_topic" default="/mushr_sim/reposition" />
   <arg name="estimate_topic" default="/pose_estimate" />
   <arg name="goal_topic" default="/move_base_simple/goal" />
   <arg name="car_name" default="car" />
@@ -8,9 +8,9 @@
   <arg name="type_topic" default="/foxglove/click_type" />
 
   <!-- <node pkg="nav_msg_converter" type="nav_msg_converter_node" name="nav_msg_converter_node" /> -->
-  <node pkg="mushr_sim" type="nav_msg_converter" name="nav_msg_converter">
+  <node pkg="mushr_base" type="nav_msg_converter" name="nav_msg_converter">
     <param name="car_name" value="$(arg car_name)" />
-    <param name="start_topic" value="/$(arg car_name)$(arg start_topic)" />
+    <param name="start_topic" value="$(arg start_topic)" />
     <param name="goal_topic" value="$(arg goal_topic)" />
     <param name="pose_topic" value="$(arg pose_topic)" />
     <param name="estimate_topic" value="$(arg estimate_topic)" />

--- a/launch/teleop.launch
+++ b/launch/teleop.launch
@@ -41,6 +41,10 @@
         <arg name="use_mocap" value="$(arg use_mocap)" />
     </include>
 
+    <include file="$(find mushr_sim)/launch/nav_msg_converter.launch">
+      <arg name="car_name" value="$(arg car_name)" />
+    </include>
+
     <node pkg="robot_state_publisher" type="robot_state_publisher" name="state_publisher">
       <param name="tf_prefix" value="$(arg car_name)"/>
       <param name="robot_description" value="/$(arg car_name)/robot_description"/>

--- a/scripts/nav_msg_converter
+++ b/scripts/nav_msg_converter
@@ -1,0 +1,35 @@
+#!/usr/bin/python3
+
+# Copyright (c) 2022, The Personal Robotics Lab, The MuSHR Team, The Contributors of MuSHR
+# License: BSD 3-Clause. See LICENSE.md file in root directory.
+
+import rospy
+from threading import Thread
+from mushr_sim.nav_msg_converter import NavMsgConverter
+
+
+class ConverterThread(Thread):
+    def __init__(self):
+        super(ConverterThread, self).__init__()
+
+    def run(self):
+        self.converter = NavMsgConverter()
+
+    def shutdown(self):
+        self.converter.root.quit()
+        super(ConverterThread, self).shutdown()
+
+
+def main():
+    rospy.init_node("nav_msg_converter")
+
+    converter_thread = ConverterThread()
+    converter_thread.start()
+    # Spin the main thread
+    rospy.spin()
+    # We either got SIGINT from control-C or ROS is otherwise coming down.
+    converter_thread.converter.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/nav_msg_converter
+++ b/scripts/nav_msg_converter
@@ -5,7 +5,7 @@
 
 import rospy
 from threading import Thread
-from mushr_sim.nav_msg_converter import NavMsgConverter
+from mushr_base.nav_msg_converter import NavMsgConverter
 
 
 class ConverterThread(Thread):

--- a/src/mushr_base/nav_msg_converter.py
+++ b/src/mushr_base/nav_msg_converter.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+
+"""
+Converts FoxGlove ROS messages into a format compatible with the MuSHR stack.
+Author: Schiffer
+"""
+
+import rospy
+from std_msgs.msg import String
+from geometry_msgs.msg import PoseStamped
+
+class NavMsgConverter:
+  def __init__(self) -> None:
+    """
+    Initialize Navigation Messages Converter.
+    Attributes:
+        name (string) rosnode name
+    """
+    self.pose = None
+    self.type = None
+
+    # Create the subscribers
+    self.pose_sub = rospy.Subscriber(
+      rospy.get_param("~pose_topic"), PoseStamped, self.save_pose, queue_size=100
+    )
+    self.type_sub = rospy.Subscriber(
+      rospy.get_param("~type_topic"), String, self.save_type, queue_size=100
+    )
+
+    # Create the publishers
+    self.goal_pub = rospy.Publisher(rospy.get_param("~goal_topic"), PoseStamped, queue_size=1)
+    self.car_pose_pub = rospy.Publisher(rospy.get_param("~start_topic"), PoseStamped, queue_size=1)
+    self.pose_estimate_pub = rospy.Publisher(rospy.get_param("~estimate_topic"), PoseStamped, queue_size=1)
+
+  def save_pose(self, pose_msg: PoseStamped) -> None:
+    """
+    Take a pose stamped message and save it.
+    """
+    self.pose = pose_msg
+  
+  def save_type(self, type_msg: String) -> None:
+    self.type = type_msg.data
+    if self.type != 'pose' and self.type != 'goal' and self.type != 'estimate':
+      raise Exception(f'Invalid type detected {self.type}')
+    if self.pose is not None:
+        self.publish()
+  
+  def publish(self) -> None:
+    if self.type == 'pose':
+      self.car_pose_pub.publish(self.pose)
+    elif self.type == 'estimate':
+      self.pose_estimate_pub.publish(self.pose)
+    else:
+      self.goal_pub.publish(self.pose)
+    self.pose = None
+    self.type = None

--- a/src/mushr_base/nav_msg_converter.py
+++ b/src/mushr_base/nav_msg_converter.py
@@ -16,12 +16,11 @@ class NavMsgConverter:
     Attributes:
         name (string) rosnode name
     """
-    self.pose = None
     self.type = None
 
     # Create the subscribers
     self.pose_sub = rospy.Subscriber(
-      rospy.get_param("~pose_topic"), PoseStamped, self.save_pose, queue_size=100
+      rospy.get_param("~pose_topic"), PoseStamped, self.publish_pose, queue_size=100
     )
     self.type_sub = rospy.Subscriber(
       rospy.get_param("~type_topic"), String, self.save_type, queue_size=100
@@ -32,25 +31,21 @@ class NavMsgConverter:
     self.car_pose_pub = rospy.Publisher(rospy.get_param("~start_topic"), PoseStamped, queue_size=1)
     self.pose_estimate_pub = rospy.Publisher(rospy.get_param("~estimate_topic"), PoseStamped, queue_size=1)
 
-  def save_pose(self, pose_msg: PoseStamped) -> None:
+  def publish_pose(self, pose_msg: PoseStamped) -> None:
     """
     Take a pose stamped message and save it.
     """
-    self.pose = pose_msg
+    print("publishing")
+    if self.type == 'goal':
+      self.goal_pub.publish(pose_msg)
+    elif self.type == 'estimate':
+      self.pose_estimate_pub.publish(pose_msg)
+    else:
+      self.car_pose_pub.publish(pose_msg)
   
   def save_type(self, type_msg: String) -> None:
     self.type = type_msg.data
+    print("type: " + str(self.type))
     if self.type != 'pose' and self.type != 'goal' and self.type != 'estimate':
       raise Exception(f'Invalid type detected {self.type}')
-    if self.pose is not None:
-        self.publish()
-  
-  def publish(self) -> None:
-    if self.type == 'pose':
-      self.car_pose_pub.publish(self.pose)
-    elif self.type == 'estimate':
-      self.pose_estimate_pub.publish(self.pose)
-    else:
-      self.goal_pub.publish(self.pose)
-    self.pose = None
-    self.type = None
+


### PR DESCRIPTION
Adds the the message converter node into the noetic branch. This node converts the messages we see in foxglove as topics into the appropriate ROS topics compatible with the MuSHR navigation stack. This includes compatibility with a true particle filter "pose estimate," which we use to give the pf an estimate rather than setting the position of the car itself.